### PR TITLE
fix: make credit-card pipeline and HelmInstall RGD work end-to-end

### DIFF
--- a/bootstrap/credit-card-pipeline.tf
+++ b/bootstrap/credit-card-pipeline.tf
@@ -15,7 +15,12 @@ locals {
   java_repo_name       = "credit-card-java"
   data_plane_repo_name = "credit-card-data-plane"
   java_ecr_name        = "credit-card"
-  chart_ecr_name       = "credit-card-chart"
+  # The Helm chart is named "credit-card" in Chart.yaml, so `helm push` stores
+  # it at <registry>/<basepath>/credit-card. We push under the "charts/"
+  # basepath to keep the chart in its own ECR repo, separate from the Java
+  # image repo (also "credit-card"). Otherwise chart + image collide and the
+  # pipeline's describe-images picks the wrong artifact.
+  chart_ecr_name       = "charts/credit-card"
 }
 
 ################################################################################
@@ -56,6 +61,16 @@ resource "aws_ecr_repository" "credit_card_java" {
   image_scanning_configuration {
     scan_on_push = true
   }
+
+  tags = var.tags
+}
+
+# Dedicated ECR repository for the packaged Helm chart (OCI). ECR does not
+# create repositories on push, so it must exist before `helm push`.
+resource "aws_ecr_repository" "credit_card_chart" {
+  name                 = local.chart_ecr_name
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
 
   tags = var.tags
 }
@@ -169,7 +184,8 @@ resource "aws_iam_role_policy" "codebuild_credit_card" {
           "ecr:DescribeImages"
         ]
         Resource = [
-          aws_ecr_repository.credit_card_java.arn
+          aws_ecr_repository.credit_card_java.arn,
+          aws_ecr_repository.credit_card_chart.arn
         ]
       },
       {
@@ -215,10 +231,14 @@ resource "aws_iam_role_policy" "codebuild_credit_card" {
         ]
       },
       {
-        Sid      = "StartBuild"
-        Effect   = "Allow"
-        Action   = "codebuild:StartBuild"
-        Resource = "*"
+        Sid    = "StartBuild"
+        Effect = "Allow"
+        Action = "codebuild:StartBuild"
+        Resource = [
+          aws_codebuild_project.credit_card_java.arn,
+          aws_codebuild_project.credit_card_chart.arn,
+          aws_codebuild_project.credit_card_update_ops.arn
+        ]
       }
     ]
   })
@@ -437,7 +457,7 @@ resource "aws_codebuild_project" "credit_card_chart" {
               sed -i "s|repository:.*|repository: $IMAGE_ECR_REPO|" data-plane/credit-card/values.yaml
             - helm package data-plane/credit-card
             - CHART_VERSION=$(grep '^version:' data-plane/credit-card/Chart.yaml | awk '{print $2}')
-            - helm push credit-card-$CHART_VERSION.tgz oci://$CHART_ECR_REPO
+            - helm push credit-card-$CHART_VERSION.tgz oci://$CHART_ECR_REPO/charts
       artifacts:
         files:
           - '**/*'
@@ -498,6 +518,16 @@ resource "aws_codebuild_project" "credit_card_update_ops" {
       name  = "JAVA_ECR_NAME"
       value = local.java_ecr_name
     }
+    # The apps ApplicationSet reads clusterName + namespace from config.json,
+    # so they must be preserved on every regeneration.
+    environment_variable {
+      name  = "CLUSTER_NAME"
+      value = "credit-card-development"
+    }
+    environment_variable {
+      name  = "APP_NAMESPACE"
+      value = "credit-card"
+    }
   }
 
   source {
@@ -520,32 +550,17 @@ resource "aws_codebuild_project" "credit_card_update_ops" {
                 --arg url "$CHART_ECR_REPO" \
                 --arg name "$CHART_ECR_NAME" \
                 --arg version "$CHART_VERSION" \
-                '{chartUrl: $url, chartName: $name, chartVersion: $version}')
+                --arg cluster "$CLUSTER_NAME" \
+                --arg ns "$APP_NAMESPACE" \
+                '{chartUrl: $url, chartName: $name, chartVersion: $version, clusterName: $cluster, namespace: $ns}')
 
               CONFIG_B64=$(echo "$CONFIG_JSON" | base64)
 
-              # Build the values.yaml content with the new image tag
-              VALUES_CONTENT=$(cat <<VALEOF
-replicaCount: 2
-
-image:
-  repository: $IMAGE_ECR_REPO
-  tag: "$IMAGE_TAG"
-  pullPolicy: IfNotPresent
-
-service:
-  type: ClusterIP
-  port: 8080
-
-resources:
-  requests:
-    cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 500m
-    memory: 512Mi
-VALEOF
-              )
+              # Build the values.yaml content with the new image tag.
+              # Uses printf (not a column-0 heredoc) so the buildspec stays
+              # uniformly indented and remains valid YAML after the Terraform
+              # indented-heredoc (<<-) dedent.
+              VALUES_CONTENT=$(printf 'replicaCount: 2\n\nimage:\n  repository: %s\n  tag: "%s"\n  pullPolicy: IfNotPresent\n\nservice:\n  type: ClusterIP\n  port: 8080\n\nresources:\n  requests:\n    cpu: 100m\n    memory: 256Mi\n  limits:\n    cpu: 500m\n    memory: 512Mi\n' "$IMAGE_ECR_REPO" "$IMAGE_TAG")
               VALUES_B64=$(echo "$VALUES_CONTENT" | base64)
 
               PUT_FILES=$(echo '[]' | jq \

--- a/bootstrap/templates/project.yaml.tftpl
+++ b/bootstrap/templates/project.yaml.tftpl
@@ -23,36 +23,14 @@ spec:
     - server: "*"
       namespace: "*"
 
-  # Allowed cluster-scoped resources
+  # Allowed cluster-scoped resources. Broad by design: workload charts such as
+  # kube-prometheus-stack and aws-load-balancer-controller install CRDs and
+  # ClusterRoles, so the platform project must permit cluster-scoped kinds.
   clusterResourceWhitelist:
-    - group: kro.run
+    - group: "*"
       kind: "*"
-    - group: platform.controlplane.io
-      kind: "*"
-    - group: ""
-      kind: Namespace
-    - group: services.k8s.aws
-      kind: IAMRoleSelector
 
   # Allowed namespace-scoped resources
   namespaceResourceWhitelist:
-    - group: kro.run
-      kind: "*"
-    - group: platform.controlplane.io
-      kind: "*"
-    - group: ""
-      kind: "*"
-    - group: apps
-      kind: "*"
-    - group: batch
-      kind: "*"
-    - group: networking.k8s.io
-      kind: "*"
-    - group: argoproj.io
-      kind: "*"
-    - group: services.k8s.aws
-      kind: "*"
-    - group: iam.services.k8s.aws
-      kind: "*"
-    - group: eks.services.k8s.aws
+    - group: "*"
       kind: "*"

--- a/catalog/helm-install.yaml
+++ b/catalog/helm-install.yaml
@@ -34,9 +34,11 @@ spec:
       targetRevision: string | default=* description="Chart version"
       namespace: string | required=true description="Target namespace for the release"
 
-      # Values
-      values: string | description="Inline Helm values (YAML string)"
-      parameters: "[]HelmValue | description=\"Individual Helm value overrides\""
+      # Values — both are optional; defaults let KRO resolve the template when
+      # a HelmInstall provides only one of them (e.g. monitoring uses `values`,
+      # ingress uses `parameters`).
+      values: string | default="" description="Inline Helm values (YAML string)"
+      parameters: "[]HelmValue | default=[] description=\"Individual Helm value overrides\""
 
       # Sync policy
       autoSync: "boolean | default=true"
@@ -81,6 +83,10 @@ spec:
             syncOptions:
               - "CreateNamespace=${string(schema.spec.createNamespace)}"
               - ApplyOutOfSyncOnly=true
+              # Server-side apply avoids the last-applied-configuration
+              # annotation size limit that large CRDs (e.g. Prometheus) exceed,
+              # which otherwise keeps the app perpetually OutOfSync.
+              - ServerSideApply=true
             retry:
               limit: 3
               backoff:


### PR DESCRIPTION
## Summary

Fixes several bugs found while deploying the platform end-to-end in a
single-account setup. Without these, the `credit-card` pipeline's final stage
fails and the HelmInstall-based workloads never sync. All changes were
validated live: pipeline runs green and every ArgoCD Application reaches
Synced/Healthy.

## Fixes

### `bootstrap/credit-card-pipeline.tf`
- **UpdateOps buildspec was invalid YAML.** The nested `<<VALEOF` heredoc placed
  its lines at column 0, which broke both Terraform's indented-heredoc (`<<-`)
  dedent and the CodeBuild YAML block scalar (`did not find expected <document
  start>`). Replaced it with a single `printf` so the buildspec stays uniformly
  indented.
- **Helm chart collided with the Java image in ECR.** The chart is named
  `credit-card` in `Chart.yaml`, so `helm push oci://<registry>` stored it in
  the same `credit-card` repo as the Docker images, and `describe-images` then
  picked the wrong artifact. The chart is now pushed under a `charts/` basepath
  into a dedicated `charts/credit-card` ECR repo (new `aws_ecr_repository`),
  with the CodeBuild ECR policy updated accordingly.
- **`config.json` lost `clusterName`/`namespace` on every pipeline run.** The
  apps ApplicationSet requires them (`goTemplateOptions: missingkey=error`), so
  the generated Application failed with `map has no entry for key "namespace"`.
  Added `CLUSTER_NAME`/`APP_NAMESPACE` and include them in the emitted JSON.

> Note: this file also carries a small least-privilege refinement to the
> `StartBuild` IAM statement (scoping it to the three pipeline CodeBuild project
> ARNs instead of `*`) that was already present in the working tree.

### `catalog/helm-install.yaml`
- **HelmInstall RGD failed when only one of `values`/`parameters` was set.**
  Referencing an unset optional field raised `no such key: parameters`.
  Added `default=""` / `default=[]` so KRO resolves the template regardless of
  which field a claim uses (monitoring uses `values`, ingress uses `parameters`).
- Added `ServerSideApply=true` to the sync options so large CRDs (e.g. the
  Prometheus operator) don't exceed the `last-applied-configuration` annotation
  size limit and leave the app perpetually OutOfSync.

### `bootstrap/templates/project.yaml.tftpl`
- The `control-plane` AppProject rejected cluster-scoped resources
  (`CustomResourceDefinition is not permitted in project control-plane`), so
  charts that ship CRDs/ClusterRoles (kube-prometheus-stack,
  aws-load-balancer-controller) could not sync. Broadened the cluster and
  namespace resource whitelists to `*`/`*`.

## Testing

- `credit-card-pipeline` completes all four stages (Source → BuildImage →
  PackageChart → UpdateOps).
- ArgoCD Applications `catalog`, `credit-card-dataplane-development`,
  `credit-card-apps-development`, `credit-card-kube-prometheus-stack`, and
  `credit-card-aws-load-balancer-controller` all reach Synced/Healthy; the
  `credit-card` workload runs 2/2 on the spoke cluster.
